### PR TITLE
Fix role name to conform to Ansible-Galaxy

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,5 +1,7 @@
+---
 galaxy_info:
-  role_name: azure-ad-app
+  role_name: azure_ad_app
+  namespace: lukapetrovic_git
   author: lukapetrovic
   description: Ansible role to create Azure AD App Registrations, create/rotate their passwords and optionally save them in an Azure KeyVault.
   license: MIT

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,6 @@
 ---
 galaxy_info:
   role_name: azure_ad_app
-  namespace: lukapetrovic_git
   author: lukapetrovic
   description: Ansible role to create Azure AD App Registrations, create/rotate their passwords and optionally save them in an Azure KeyVault.
   license: MIT


### PR DESCRIPTION
# Pull Request Description
Changed role name to conform to: [https://old-galaxy.ansible.com/docs/contributing/creating_role.html#role-names](https://old-galaxy.ansible.com/docs/contributing/creating_role.html#role-names)

## Change type

- [x] Bug fix (non-breaking change which fixes a specific issue)
- [ ] New feature (non-breaking change adding new functionality)
- [ ] Breaking change (fix or feature that potentially causes existing functionality to fail)
- [ ] Change that does not affect Ansible Role code (Github Actions Workflow, Documentation, or similair)
